### PR TITLE
feat: Globus Transfer Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+static-*.json
 
 # dependencies
 /node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@globus/react-auth-context": "^0.0.6",
         "@globus/sdk": "^4.3.1",
+        "@tanstack/react-query": "^5.56.2",
         "framer-motion": "^11.3.7",
         "lodash": "^4.17.21",
         "next": "14.2.13",
@@ -2998,6 +2999,30 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.56.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.56.2.tgz",
+      "integrity": "sha512-gor0RI3/R5rVV3gXfddh1MM+hgl0Z4G7tj6Xxpq6p2I03NGPaJ8dITY9Gz05zYYb/EJq9vPas/T4wn9EaDPd4Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.56.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.56.2.tgz",
+      "integrity": "sha512-SR0GzHVo6yzhN72pnRhkEFRAHMsUo5ZPzAxfTMvUxFIDVS6W9LYUp6nXW3fcHVdg0ZJl8opSH85jqahvm6DSVg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.56.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "lodash": "^4.17.21",
         "next": "14.2.13",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@heroicons/react": "^2.1.5",
@@ -10552,6 +10553,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -10967,6 +10976,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
+      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lodash": "^4.17.21",
     "next": "14.2.13",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@heroicons/react": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@fontsource/ibm-plex-sans": "^5.0.20",
     "@globus/react-auth-context": "^0.0.6",
     "@globus/sdk": "^4.3.1",
+    "@tanstack/react-query": "^5.56.2",
     "framer-motion": "^11.3.7",
     "lodash": "^4.17.21",
     "next": "14.2.13",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "packages": {
     ".": {
-      "component": "",
+      "package-name": "",
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": false,
@@ -9,7 +9,8 @@
       "draft": false,
       "prerelease": false,
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": ["src/globus/utils.ts"]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/src/app/authenticate/page.tsx
+++ b/src/app/authenticate/page.tsx
@@ -4,32 +4,53 @@ import { useRouter } from "next/navigation";
 import { useGlobusAuth } from "@globus/react-auth-context";
 import { Center, Spinner, Text } from "@chakra-ui/react";
 import { isFeatureEnabled } from "../../../static";
-
-const REDIRECT_KEY = "postLoginRedirectUrl";
-
-export function setPostLoginRedirectUrl(url: string) {
-  sessionStorage.setItem(REDIRECT_KEY, url);
-}
+import { useOAuthStore } from "@/store/oauth";
 
 function Authenticate() {
   const auth = useGlobusAuth();
+  const oauthStore = useOAuthStore();
   const router = useRouter();
   const instance = auth.authorization;
 
+  /**
+   * Attempt to handle the incoming OAuth2 redirect.
+   */
   useEffect(() => {
     async function attempt() {
-      if (auth.isAuthenticated) {
-        const replaceWith = sessionStorage.getItem(REDIRECT_KEY) ?? "/";
-        sessionStorage.removeItem(REDIRECT_KEY);
-        return router.replace(replaceWith);
-      } else {
-        await instance?.handleCodeRedirect({
-          shouldReplace: false,
-        });
+      if (!instance) {
+        return;
       }
+      /**
+       * Attempt to handle incoming OAuth2 redirect.
+       */
+      await instance.handleCodeRedirect({
+        /**
+         * We'll handle the redirect ourselves...
+         */
+        shouldReplace: false,
+      });
     }
     attempt();
-  }, [router, instance, instance?.handleCodeRedirect, auth.isAuthenticated]);
+  }, [instance]);
+
+  /**
+   * Once the user is authenticated, refresh the tokens and redirect to the transfer page.
+   */
+  useEffect(() => {
+    async function redirect() {
+      if (!instance || !auth.isAuthenticated) {
+        return;
+      }
+      await instance.refreshTokens();
+      const replaceWith = oauthStore.replaceWith;
+      router.replace(replaceWith);
+      return () => {
+        oauthStore.reset();
+      };
+    }
+    redirect();
+  }, [router, instance, auth.isAuthenticated, oauthStore]);
+
   return (
     <>
       <Center mt={4}>

--- a/src/app/authenticate/page.tsx
+++ b/src/app/authenticate/page.tsx
@@ -5,6 +5,12 @@ import { useGlobusAuth } from "@globus/react-auth-context";
 import { Center, Spinner, Text } from "@chakra-ui/react";
 import { isFeatureEnabled } from "../../../static";
 
+const REDIRECT_KEY = "postLoginRedirectUrl";
+
+export function setPostLoginRedirectUrl(url: string) {
+  sessionStorage.setItem(REDIRECT_KEY, url);
+}
+
 function Authenticate() {
   const auth = useGlobusAuth();
   const router = useRouter();
@@ -13,7 +19,9 @@ function Authenticate() {
   useEffect(() => {
     async function attempt() {
       if (auth.isAuthenticated) {
-        return router.replace("/");
+        const replaceWith = sessionStorage.getItem(REDIRECT_KEY) ?? "/";
+        sessionStorage.removeItem(REDIRECT_KEY);
+        return router.replace(replaceWith);
       } else {
         await instance?.handleCodeRedirect({
           shouldReplace: false,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,6 @@ import {
 
 import { Provider as GlobusAuthorizationManagerProvider } from "@globus/react-auth-context";
 import Header from "@/components/Header";
-import TransferDrawer from "@/components/Transfer/Drawer";
 import { CLIENT_INFO } from "@/globus/utils";
 
 const env = getEnvironment();
@@ -65,7 +64,6 @@ export default function RootLayout({
           >
             <Header />
             {children}
-            {isTransferEnabled && <TransferDrawer />}
           </GlobusAuthorizationManagerProvider>
         </ThemeProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { ThemeProvider } from "./theme-provider";
-import { info } from "@globus/sdk/cjs";
+import { info } from "@globus/sdk";
 
 import {
   getEnvironment,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { PropsWithChildren, useEffect } from "react";
 import { ThemeProvider } from "./theme-provider";
 import { info } from "@globus/sdk";
 
@@ -8,13 +8,17 @@ import {
   getEnvironment,
   getRedirectUri,
   getAttribute,
-  isFeatureEnabled,
   isTransferEnabled,
+  isAuthenticationEnabled,
 } from "../../static";
 
-import { Provider as GlobusAuthorizationManagerProvider } from "@globus/react-auth-context";
+import {
+  Provider as GlobusAuthorizationManagerProvider,
+  useGlobusAuth,
+} from "@globus/react-auth-context";
 import Header from "@/components/Header";
 import { CLIENT_INFO } from "@/globus/utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const env = getEnvironment();
 if (env) {
@@ -35,12 +39,46 @@ const scopes = [
   isTransferEnabled && "urn:globus:auth:scope:transfer.api.globus.org:all",
 ].join(" ");
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      /**
+       * Many errors encountered during queries need to be manually addressed,
+       * so we disable automatic retries by default.
+       */
+      retry: false,
+    },
+  },
+});
+function reset() {
+  queryClient.cancelQueries();
+  queryClient.removeQueries();
+  queryClient.clear();
+}
+
+const QueryProvider = ({ children }: PropsWithChildren) => {
+  const auth = useGlobusAuth();
+  useEffect(() => {
+    auth.authorization?.events.revoke.addListener(reset);
+    auth.authorization?.events.authenticated.addListener(reset);
+    return () => {
+      auth.authorization?.events.revoke.removeListener(reset);
+      auth.authorization?.events.authenticated.removeListener(reset);
+    };
+  }, [auth.authorization]);
+  return (
+    <>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </>
+  );
+};
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  if (!isFeatureEnabled("authentication")) {
+  if (!isAuthenticationEnabled) {
     return (
       <html lang="en">
         <body>
@@ -62,8 +100,10 @@ export default function RootLayout({
             client={client}
             scopes={scopes}
           >
-            <Header />
-            {children}
+            <QueryProvider>
+              <Header />
+              {children}
+            </QueryProvider>
           </GlobusAuthorizationManagerProvider>
         </ThemeProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,15 +2,20 @@
 
 import React from "react";
 import { ThemeProvider } from "./theme-provider";
+import { info } from "@globus/sdk/cjs";
+
 import {
   getEnvironment,
   getRedirectUri,
   getAttribute,
   isFeatureEnabled,
+  isTransferEnabled,
 } from "../../static";
 
 import { Provider as GlobusAuthorizationManagerProvider } from "@globus/react-auth-context";
 import Header from "@/components/Header";
+import TransferDrawer from "@/components/Transfer/Drawer";
+import { CLIENT_INFO } from "@/globus/utils";
 
 const env = getEnvironment();
 if (env) {
@@ -18,9 +23,18 @@ if (env) {
   globalThis.GLOBUS_SDK_ENVIRONMENT = env;
 }
 
+info.addClientInfo(CLIENT_INFO);
+
 const redirect = getRedirectUri();
 const client = getAttribute("globus.application.client_id");
-const scopes = "urn:globus:auth:scope:search.api.globus.org:search";
+
+const scopes = [
+  "urn:globus:auth:scope:search.api.globus.org:search",
+  /**
+   * If Globus Transfer functionality is enabled, we'll need to ask for the Transfer scope.
+   */
+  isTransferEnabled && "urn:globus:auth:scope:transfer.api.globus.org:all",
+].join(" ");
 
 export default function RootLayout({
   children,
@@ -51,6 +65,7 @@ export default function RootLayout({
           >
             <Header />
             {children}
+            {isTransferEnabled && <TransferDrawer />}
           </GlobusAuthorizationManagerProvider>
         </ThemeProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,8 +36,12 @@ const scopes = [
   /**
    * If Globus Transfer functionality is enabled, we'll need to ask for the Transfer scope.
    */
-  isTransferEnabled && "urn:globus:auth:scope:transfer.api.globus.org:all",
-].join(" ");
+  isTransferEnabled
+    ? "urn:globus:auth:scope:transfer.api.globus.org:all"
+    : null,
+]
+  .filter(Boolean)
+  .join(" ");
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import {
   Container,
   Text,

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -35,7 +35,7 @@ import {
 } from "@heroicons/react/24/outline";
 import NextLink from "next/link";
 import { CollectionSearch } from "@/globus/collection-browser/CollectionBrowser";
-import { transfer, webapp } from "@globus/sdk/cjs";
+import { transfer, webapp } from "@globus/sdk";
 import { useGlobusAuth } from "@/globus/globus-auth-context/useGlobusAuth";
 import { isTransferEnabled } from "../../../static";
 

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -1,0 +1,274 @@
+"use client";
+import React, { useState } from "react";
+import {
+  Container,
+  Text,
+  Link,
+  Flex,
+  Center,
+  Heading,
+  Card,
+  CardHeader,
+  CardBody,
+  Box,
+  HStack,
+  Icon,
+  IconButton,
+  Spacer,
+  Stack,
+  Button,
+  VStack,
+  FormControl,
+  FormLabel,
+  Input,
+  useToast,
+  SimpleGrid,
+  Tooltip,
+  Alert,
+  AlertIcon,
+  AlertTitle,
+} from "@chakra-ui/react";
+import { Item, useGlobusTransferStore } from "@/store/globus-transfer";
+import {
+  XCircleIcon,
+  ArrowTopRightOnSquareIcon,
+} from "@heroicons/react/24/outline";
+import NextLink from "next/link";
+import { CollectionSearch } from "@/globus/collection-browser/CollectionBrowser";
+import { transfer, webapp } from "@globus/sdk/cjs";
+import { useGlobusAuth } from "@/globus/globus-auth-context/useGlobusAuth";
+import { isTransferEnabled } from "../../../static";
+
+export default function ResultPage() {
+  const auth = useGlobusAuth();
+  const toast = useToast();
+  const items = useGlobusTransferStore((state) => state.items);
+  const removeItemBySubject = useGlobusTransferStore(
+    (state) => state.removeItemBySubject,
+  );
+
+  const [transferSettings, setTransferSettings] = useState<{
+    destination: string | undefined;
+    path: string | undefined;
+    label: string | undefined;
+  }>({
+    destination: undefined,
+    path: undefined,
+    label: undefined,
+  });
+
+  if (isTransferEnabled === false) {
+    return (
+      <Center my={5}>
+        <Text fontSize="xl">
+          Globus Transfer functionality is not available in this portal.
+        </Text>
+      </Center>
+    );
+  }
+
+  const itemsByCollection = items.reduce(
+    (acc: { [key: Item["collection"]]: Item[] }, item) => {
+      if (!acc[item.collection]) {
+        acc[item.collection] = [];
+      }
+      acc[item.collection].push(item);
+      return acc;
+    },
+    {},
+  );
+
+  async function handleStartTransfer(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const { destination, path, label } = transferSettings;
+    if (!label || !path || !destination) {
+      return;
+    }
+
+    Object.keys(itemsByCollection).forEach(async (collection) => {
+      const id = await (
+        await transfer.taskSubmission.submissionId(
+          {},
+          { manager: auth.authorization },
+        )
+      ).json();
+
+      const response = await transfer.taskSubmission.submitTransfer(
+        {
+          payload: {
+            submission_id: id.value,
+            label,
+            source_endpoint: collection,
+            destination_endpoint: destination,
+            DATA: itemsByCollection[collection].map((item) => {
+              return {
+                DATA_TYPE: "transfer_item",
+                source_path: item.path,
+                /**
+                 * @todo Should we allow (or require) configuration of `item.name` and `item.type`?
+                 */
+                destination_path: `${path}${item.path}`,
+                recursive: item.type === "directory",
+              };
+            }),
+          },
+        },
+        { manager: auth.authorization },
+      );
+
+      const data = await response.json();
+
+      if (response.ok) {
+        toast({
+          title: `Transfer: ${data.code}`,
+          description: (
+            <>
+              {data.message}
+              {"task_id" in data && (
+                <Flex>
+                  <Spacer />
+                  <Link
+                    href={webapp.urlFor("TASK", [data.task_id]).toString()}
+                    isExternal
+                  >
+                    View task in Globus Web App{" "}
+                    <Icon as={ArrowTopRightOnSquareIcon} />
+                  </Link>
+                </Flex>
+              )}
+            </>
+          ),
+          status: "success",
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: `Error (${data.code})`,
+          description: data.message,
+          status: "error",
+          isClosable: true,
+        });
+      }
+    });
+  }
+
+  return (
+    <Container maxW="container.xl" p={4}>
+      {auth.isAuthenticated === false && (
+        <Alert status="error" my={2}>
+          <AlertIcon />
+          <AlertTitle>You must authetnicate to initiate a transfer.</AlertTitle>
+        </Alert>
+      )}
+
+      {items.length === 0 ? (
+        <Center>
+          <Text fontSize="xl">No items in the transfer list.</Text>
+        </Center>
+      ) : (
+        <SimpleGrid columns={2} spacing={10}>
+          <Box>
+            {Object.keys(itemsByCollection).map((collection, i) => (
+              <Card key={collection}>
+                <CardHeader>
+                  <Flex>
+                    <Heading size="sm">
+                      Collection {i + 1} ({collection})
+                    </Heading>
+                    <Spacer />
+                    {/* <Button size="xs">Remove Collection + Items</Button> */}
+                  </Flex>
+                </CardHeader>
+                <CardBody>
+                  <Stack>
+                    {itemsByCollection[collection].map((item) => (
+                      <Box key={item.subject}>
+                        <HStack align="flex-start">
+                          <IconButton
+                            size="xs"
+                            variant="ghost"
+                            aria-label="Remove item from transfer list"
+                            icon={<Icon as={XCircleIcon} boxSize={4} />}
+                            onClick={() => removeItemBySubject(item.subject)}
+                          />
+                          <Stack spacing={1}>
+                            <Link
+                              noOfLines={1}
+                              as={NextLink}
+                              href={`/results?subject=${item.subject}`}
+                            >
+                              {item.label}
+                            </Link>
+                            <Tooltip label={item.path}>
+                              <Text noOfLines={1} fontSize="xs" maxWidth="50%">
+                                {item.path}
+                              </Text>
+                            </Tooltip>
+                          </Stack>
+                          <Spacer />
+                        </HStack>
+                      </Box>
+                    ))}
+                  </Stack>
+                </CardBody>
+              </Card>
+            ))}
+          </Box>
+          <Box>
+            <form onSubmit={(e) => handleStartTransfer(e)}>
+              <fieldset disabled={!auth.isAuthenticated}>
+                <VStack>
+                  <FormControl>
+                    <FormLabel>Destination</FormLabel>
+                    <CollectionSearch
+                      onSelect={(destination) => {
+                        setTransferSettings({
+                          ...transferSettings,
+                          destination: destination.id,
+                        });
+                      }}
+                    />
+                  </FormControl>
+                  <FormControl>
+                    <FormLabel>Path</FormLabel>
+                    <Input
+                      disabled={!auth.isAuthenticated}
+                      onChange={(e) => {
+                        setTransferSettings({
+                          ...transferSettings,
+                          path: e.currentTarget.value,
+                        });
+                      }}
+                    />
+                  </FormControl>
+                  <FormControl>
+                    <FormLabel>Label</FormLabel>
+                    <Input
+                      disabled={!auth.isAuthenticated}
+                      onChange={(e) => {
+                        setTransferSettings({
+                          ...transferSettings,
+                          label: e.currentTarget.value,
+                        });
+                      }}
+                    />
+                  </FormControl>
+                  <Button
+                    w="100%"
+                    isDisabled={
+                      !transferSettings?.destination || !transferSettings?.path
+                    }
+                    type="submit"
+                  >
+                    Start Transfer
+                  </Button>
+                </VStack>
+              </fieldset>
+            </form>
+          </Box>
+        </SimpleGrid>
+      )}
+    </Container>
+  );
+}

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -27,17 +27,20 @@ import {
   Alert,
   AlertIcon,
   AlertTitle,
+  FormHelperText,
 } from "@chakra-ui/react";
-import { Item, useGlobusTransferStore } from "@/store/globus-transfer";
 import {
   XCircleIcon,
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
 import NextLink from "next/link";
-import { CollectionSearch } from "@/globus/collection-browser/CollectionBrowser";
 import { transfer, webapp } from "@globus/sdk";
-import { useGlobusAuth } from "@/globus/globus-auth-context/useGlobusAuth";
+import { useGlobusAuth } from "@globus/react-auth-context";
+
+import { Item, useGlobusTransferStore } from "@/store/globus-transfer";
+import { CollectionSearch } from "@/globus/collection-browser/CollectionBrowser";
 import { isTransferEnabled } from "../../../static";
+import PathVerifier from "@/globus/PathVerifier";
 
 export default function ResultPage() {
   const auth = useGlobusAuth();
@@ -82,7 +85,7 @@ export default function ResultPage() {
     e.preventDefault();
 
     const { destination, path, label } = transferSettings;
-    if (!label || !path || !destination) {
+    if (!path || !destination) {
       return;
     }
 
@@ -158,7 +161,7 @@ export default function ResultPage() {
       {auth.isAuthenticated === false && (
         <Alert status="error" my={2}>
           <AlertIcon />
-          <AlertTitle>You must authetnicate to initiate a transfer.</AlertTitle>
+          <AlertTitle>You must authenticate to initiate a transfer.</AlertTitle>
         </Alert>
       )}
 
@@ -241,6 +244,14 @@ export default function ResultPage() {
                         });
                       }}
                     />
+                    <FormHelperText>
+                      {transferSettings?.path && (
+                        <PathVerifier
+                          path={transferSettings.path}
+                          collectionId={transferSettings.destination}
+                        />
+                      )}
+                    </FormHelperText>
                   </FormControl>
                   <FormControl>
                     <FormLabel>Label</FormLabel>

--- a/src/components/AddToTransferList.tsx
+++ b/src/components/AddToTransferList.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Button, Link } from "@chakra-ui/react";
+
+import { useGlobusTransferStore } from "@/store/globus-transfer";
+import { getTransferDetailsFromResult } from "./Result";
+
+import { getValueFromAttribute, isTransferEnabled } from "../../static";
+
+import type { GMetaResult } from "@globus/sdk/services/search/service/query";
+import { useGlobusAuth } from "@globus/react-auth-context";
+
+export default function AddToTransferList({
+  result,
+  iconOnly = false,
+}: {
+  result: GMetaResult;
+  iconOnly?: boolean;
+}) {
+  const auth = useGlobusAuth();
+  const items = useGlobusTransferStore((state) => state.items);
+  const addTransferItem = useGlobusTransferStore((state) => state.addItem);
+  const removeItemBySubject = useGlobusTransferStore(
+    (state) => state.removeItemBySubject,
+  );
+
+  const [itemLabel, setItemLabel] = useState<string>();
+
+  const isSelected = useMemo(() => {
+    return items.some((item) => item.subject === result.subject);
+  }, [result.subject, items]);
+
+  useEffect(() => {
+    async function bootstrap() {
+      const heading = await getValueFromAttribute<string>(
+        result,
+        "components.Result.heading",
+      );
+      setItemLabel(heading);
+    }
+    bootstrap();
+  }, [result]);
+
+  return (
+    isTransferEnabled &&
+    auth.isAuthenticated && (
+      <Button
+        as={Link}
+        size="sm"
+        onClick={
+          !isSelected
+            ? async () => {
+                const { collection, path, type } =
+                  await getTransferDetailsFromResult(result);
+
+                addTransferItem({
+                  label: itemLabel || result.subject,
+                  subject: result.subject,
+                  collection,
+                  path,
+                  type,
+                });
+              }
+            : () => removeItemBySubject(result.subject)
+        }
+      >
+        {isSelected ? "Remove from Transfer List" : "Add to Transfer List"}
+      </Button>
+    )
+  );
+}

--- a/src/components/Fields/RgbaField.tsx
+++ b/src/components/Fields/RgbaField.tsx
@@ -27,7 +27,7 @@ export default function RgbaField({
   };
 
   return (
-    <VStack>
+    <VStack display="inline-flex">
       <Box bg={`rgba(${value.join(",")})`} {...props} />
       <Code>[{value.join(",")}]</Code>
     </VStack>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,10 +15,12 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useGlobusAuth } from "@globus/react-auth-context";
-
-import { getAttribute, withFeature } from "../../static";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import Link from "next/link";
+
+import TransferDrawer from "@/components/Transfer/Drawer";
+
+import { getAttribute, withFeature } from "../../static";
 
 const SEARCH_INDEX = getAttribute("globus.search.index");
 const LOGO = getAttribute("content.logo");
@@ -33,21 +35,33 @@ export function Authentication() {
   return (
     <>
       {auth.isAuthenticated && user ? (
-        <Menu placement="bottom-end">
-          <MenuButton size="sm" as={Button} rightIcon={<ChevronDownIcon />}>
-            {user?.preferred_username}
-          </MenuButton>
-          <MenuList zIndex={2}>
-            <Box px={2} textAlign="right">
-              <Text>{user?.name}</Text>
-              <Text fontSize="sm">{user?.organization}</Text>
-            </Box>
-            <MenuDivider />
-            <MenuItem onClick={async () => await auth.authorization?.revoke()}>
-              Log Out
-            </MenuItem>
-          </MenuList>
-        </Menu>
+        <>
+          <HStack as="nav" spacing={4}>
+            <TransferDrawer />
+            <Menu placement="bottom-end">
+              <MenuButton
+                colorScheme="gray"
+                size="sm"
+                as={Button}
+                rightIcon={<ChevronDownIcon />}
+              >
+                {user?.preferred_username}
+              </MenuButton>
+              <MenuList zIndex={2}>
+                <Box px={2} textAlign="right">
+                  <Text>{user?.name}</Text>
+                  <Text fontSize="sm">{user?.organization}</Text>
+                </Box>
+                <MenuDivider />
+                <MenuItem
+                  onClick={async () => await auth.authorization?.revoke()}
+                >
+                  Log Out
+                </MenuItem>
+              </MenuList>
+            </Menu>
+          </HStack>
+        </>
       ) : (
         <Button
           size="sm"
@@ -88,7 +102,9 @@ export default function Header() {
               </Link>
             </HStack>
             {withFeature("authentication", () => (
-              <Authentication />
+              <Box>
+                <Authentication />
+              </Box>
             ))}
           </Flex>
         </Container>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,8 +81,8 @@ export default function Header() {
       as="header"
       bg="brand.800"
       minH={{ base: "50px", md: "10vh" }}
-      align={"center"}
-      justify={"center"}
+      align="center"
+      justify="center"
     >
       <Container maxW="container.xl">
         <Flex

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -77,17 +77,24 @@ export function Authentication() {
 
 export default function Header() {
   return (
-    <header>
-      <Box bg="brand.800">
-        <Container maxW="container.xl">
-          <Flex
-            minWidth="max-content"
-            alignItems="center"
-            justify="space-between"
-            h="10vh"
-          >
-            <HStack p={4} spacing="24px">
-              <Link href="/">
+    <Flex
+      as="header"
+      bg="brand.800"
+      minH={{ base: "50px", md: "10vh" }}
+      align={"center"}
+      justify={"center"}
+    >
+      <Container maxW="container.xl">
+        <Flex
+          direction={{ base: "column", md: "row" }}
+          minWidth="max-content"
+          alignItems={{ base: "flex-start", md: "center" }}
+          justify={{ base: "space-around", md: "space-between" }}
+          my={2}
+        >
+          <Box>
+            <Link href="/">
+              <HStack py={4} spacing="24px">
                 {LOGO && (
                   <Image
                     src={LOGO.src}
@@ -99,16 +106,16 @@ export default function Header() {
                 <Heading as="h1" size="md" color="white">
                   {HEADLINE}
                 </Heading>
-              </Link>
-            </HStack>
-            {withFeature("authentication", () => (
-              <Box>
-                <Authentication />
-              </Box>
-            ))}
-          </Flex>
-        </Container>
-      </Box>
-    </header>
+              </HStack>
+            </Link>
+          </Box>
+          {withFeature("authentication", () => (
+            <Box>
+              <Authentication />
+            </Box>
+          ))}
+        </Flex>
+      </Container>
+    </Flex>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,6 +18,7 @@ import { useGlobusAuth } from "@globus/react-auth-context";
 
 import { getAttribute, withFeature } from "../../static";
 import { ChevronDownIcon } from "@chakra-ui/icons";
+import Link from "next/link";
 
 const SEARCH_INDEX = getAttribute("globus.search.index");
 const LOGO = getAttribute("content.logo");
@@ -72,17 +73,19 @@ export default function Header() {
             h="10vh"
           >
             <HStack p={4} spacing="24px">
-              {LOGO && (
-                <Image
-                  src={LOGO.src}
-                  alt={LOGO.alt}
-                  boxSize="100px"
-                  objectFit="contain"
-                />
-              )}
-              <Heading as="h1" size="md" color="white">
-                {HEADLINE}
-              </Heading>
+              <Link href="/">
+                {LOGO && (
+                  <Image
+                    src={LOGO.src}
+                    alt={LOGO.alt}
+                    boxSize="100px"
+                    objectFit="contain"
+                  />
+                )}
+                <Heading as="h1" size="md" color="white">
+                  {HEADLINE}
+                </Heading>
+              </Link>
             </HStack>
             {withFeature("authentication", () => (
               <Authentication />

--- a/src/components/ResponseDrawer.tsx
+++ b/src/components/ResponseDrawer.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import {
+  useDisclosure,
+  Button,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  DrawerHeader,
+  DrawerBody,
+} from "@chakra-ui/react";
+
+export default function ResponseDrawer({ children }: { children: any }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const btnRef = React.useRef();
+
+  return (
+    <>
+      <Button
+        ref={btnRef.current}
+        colorScheme="gray"
+        onClick={onOpen}
+        size="xs"
+      >
+        View Raw Search Result
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        finalFocusRef={btnRef.current}
+        size="xl"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader />
+          <DrawerBody>{children}</DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}

--- a/src/components/ResultListing.tsx
+++ b/src/components/ResultListing.tsx
@@ -13,6 +13,7 @@ import {
   Td,
   HStack,
   Link,
+  Spacer,
 } from "@chakra-ui/react";
 import { getValueFromAttribute, getAttribute } from "../../static";
 
@@ -24,6 +25,7 @@ import {
   getProcessedField,
 } from "./Field";
 import ImageField from "./Fields/ImageField";
+import AddToTransferList from "./AddToTransferList";
 
 export type ResultListingComponentOptions = {
   /**
@@ -161,16 +163,20 @@ export default function ResultListing({ gmeta }: { gmeta: GMetaResult }) {
     <Card size="sm" w="full">
       <CardHeader>
         <Heading size="md" color="brand">
-          <Link
-            as={NextLink}
-            href={`/results?subject=${encodeURIComponent(gmeta.subject)}`}
-          >
-            {heading || (
-              <Text as="em" color="gray.500">
-                &mdash;
-              </Text>
-            )}
-          </Link>
+          <HStack>
+            <Link
+              as={NextLink}
+              href={`/results?subject=${encodeURIComponent(gmeta.subject)}`}
+            >
+              {heading || (
+                <Text as="em" color="gray.500">
+                  &mdash;
+                </Text>
+              )}
+            </Link>
+            <Spacer />
+            <AddToTransferList result={gmeta} />
+          </HStack>
         </Heading>
       </CardHeader>
       {image || summary || fields ? (

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import {
   InputGroup,
   Input,
@@ -20,14 +21,13 @@ import type { GSearchResult } from "@globus/sdk/services/search/service/query";
 import { isGError } from "@/globus/search";
 import SearchFacets from "./SearchFacets";
 import { SearchState, useSearch } from "../app/search-provider";
-import { getAttribute, isFeatureEnabled } from "../../static";
+import { getAttribute, isAuthenticationEnabled } from "../../static";
 import ResultListing from "./ResultListing";
 import { Error } from "./Error";
 import { Pagination } from "./Pagination";
 
 const SEARCH_INDEX = getAttribute("globus.search.index");
 const FACETS = getAttribute("globus.search.facets", []);
-const AUTENTICATION_ENABLED = isFeatureEnabled("authentication");
 
 function getSearchPayload(query: string, state: SearchState) {
   return {
@@ -51,7 +51,7 @@ export function Search() {
       setIsLoading(true);
 
       const headers =
-        AUTENTICATION_ENABLED &&
+        isAuthenticationEnabled &&
         auth.isAuthenticated &&
         auth.authorization?.tokens?.search?.access_token
           ? {
@@ -71,7 +71,7 @@ export function Search() {
   }, [
     query,
     search,
-    AUTENTICATION_ENABLED
+    isAuthenticationEnabled
       ? auth.authorization?.tokens?.search?.access_token
       : undefined,
   ]);

--- a/src/components/Transfer/Drawer.tsx
+++ b/src/components/Transfer/Drawer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import {
   Drawer,
@@ -23,12 +25,14 @@ import {
   HStack,
   Tooltip,
 } from "@chakra-ui/react";
+import { usePathname } from "next/navigation";
 
 import { Item, useGlobusTransferStore } from "@/store/globus-transfer";
 import NextLink from "next/link";
 import { XCircleIcon } from "@heroicons/react/24/outline";
 
 export default function TransferDrawer() {
+  const pathname = usePathname();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const items = useGlobusTransferStore((state) => state.items);
@@ -49,12 +53,15 @@ export default function TransferDrawer() {
 
   return (
     <>
-      <Box pos="fixed" bottom={0} left={0} right={0}>
-        <Box p={2}>
-          <Button colorScheme="blue" onClick={onOpen}>
-            Transfer List ({items.length})
-          </Button>
-        </Box>
+      <Box>
+        <Button
+          isDisabled={pathname === "/transfer"}
+          size="sm"
+          colorScheme="blue"
+          onClick={onOpen}
+        >
+          Transfer List ({items.length})
+        </Button>
       </Box>
       <Drawer size="xl" placement="right" onClose={onClose} isOpen={isOpen}>
         <DrawerOverlay />
@@ -98,6 +105,7 @@ export default function TransferDrawer() {
                                   noOfLines={1}
                                   as={NextLink}
                                   href={`/results?subject=${item.subject}`}
+                                  onClick={onClose}
                                 >
                                   {item.label}
                                 </Link>

--- a/src/components/Transfer/Drawer.tsx
+++ b/src/components/Transfer/Drawer.tsx
@@ -25,6 +25,10 @@ import {
   HStack,
   Tooltip,
   Badge,
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
 } from "@chakra-ui/react";
 import { usePathname } from "next/navigation";
 
@@ -79,30 +83,34 @@ export default function TransferDrawer() {
             <Flex h="100%" direction="column">
               {items.length ? (
                 <Box my={2}>
-                  <Text mb={2}>
-                    These are the entries that you have selected for data
-                    transfer. Data or data sets associated to entries may be
-                    sourced from multiple sources, which will be visible here.
-                  </Text>
-                  <Text mb={2}>
-                    Once you have finished selecting entries, the next step is
-                    to:&nbsp;
-                    <Link as={NextLink} href="/transfer" onClick={onClose}>
-                      Configure your Transfer
-                    </Link>
-                  </Text>
+                  <Alert
+                    status="info"
+                    variant="subtle"
+                    flexDirection="column"
+                    alignItems="start"
+                  >
+                    <AlertTitle>
+                      These are the entries that you have selected for data
+                      transfer.
+                    </AlertTitle>
+                    <AlertDescription>
+                      Data or datasets associated to entries may be sourced from
+                      multiple sources, which will be visible here.
+                    </AlertDescription>
+                  </Alert>
                 </Box>
               ) : null}
               <Stack spacing={2}>
                 {items.length === 0 && (
                   <>
-                    <Text fontSize="large" as="em" mt={4}>
-                      No items added.
-                    </Text>
-                    <Text>
-                      As you browse data and add entries to your Transfer List,
-                      they will appear here.
-                    </Text>
+                    <Alert status="warning">
+                      <AlertIcon />
+                      <AlertTitle>No items added.</AlertTitle>
+                      <AlertDescription>
+                        As you browse data and add entries to your Transfer
+                        List, they will appear here.
+                      </AlertDescription>
+                    </Alert>
                   </>
                 )}
                 {Object.keys(itemsByCollection).map((collection, i) => (
@@ -158,14 +166,16 @@ export default function TransferDrawer() {
                 ))}
               </Stack>
               <Spacer />
-              <Button
-                as={NextLink}
-                href="/transfer"
-                onClick={onClose}
-                isDisabled={items.length === 0}
-              >
-                Next Step: Configure your Transfer
-              </Button>
+              {items.length > 0 && (
+                <Button
+                  as={NextLink}
+                  href="/transfer"
+                  onClick={onClose}
+                  isDisabled={items.length === 0}
+                >
+                  Next Step: Configure your Transfer
+                </Button>
+              )}
             </Flex>
           </DrawerBody>
         </DrawerContent>

--- a/src/components/Transfer/Drawer.tsx
+++ b/src/components/Transfer/Drawer.tsx
@@ -24,12 +24,15 @@ import {
   Icon,
   HStack,
   Tooltip,
+  Badge,
 } from "@chakra-ui/react";
 import { usePathname } from "next/navigation";
 
 import { Item, useGlobusTransferStore } from "@/store/globus-transfer";
 import NextLink from "next/link";
-import { XCircleIcon } from "@heroicons/react/24/outline";
+import { MinusCircleIcon } from "@heroicons/react/24/outline";
+import { CollectionName } from "@/globus/Collection";
+import { isTransferEnabled } from "../../../static";
 
 export default function TransferDrawer() {
   const pathname = usePathname();
@@ -51,16 +54,19 @@ export default function TransferDrawer() {
     {},
   );
 
-  return (
+  return isTransferEnabled ? (
     <>
       <Box>
         <Button
           isDisabled={pathname === "/transfer"}
           size="sm"
-          colorScheme="blue"
+          colorScheme="brand"
           onClick={onOpen}
         >
-          Transfer List ({items.length})
+          Transfer List
+          <Badge ml={2} colorScheme="brand">
+            {items.length}
+          </Badge>
         </Button>
       </Box>
       <Drawer size="xl" placement="right" onClose={onClose} isOpen={isOpen}>
@@ -69,18 +75,42 @@ export default function TransferDrawer() {
           <DrawerHeader borderBottomWidth="1px">
             Transfer List <DrawerCloseButton />
           </DrawerHeader>
-          <DrawerBody mt={2}>
+          <DrawerBody>
             <Flex h="100%" direction="column">
+              {items.length ? (
+                <Box my={2}>
+                  <Text mb={2}>
+                    These are the entries that you have selected for data
+                    transfer. Data or data sets associated to entries may be
+                    sourced from multiple sources, which will be visible here.
+                  </Text>
+                  <Text mb={2}>
+                    Once you have finished selecting entries, the next step is
+                    to:&nbsp;
+                    <Link as={NextLink} href="/transfer" onClick={onClose}>
+                      Configure your Transfer
+                    </Link>
+                  </Text>
+                </Box>
+              ) : null}
               <Stack spacing={2}>
                 {items.length === 0 && (
-                  <Text as="em">No items added to transfer list.</Text>
+                  <>
+                    <Text fontSize="large" as="em" mt={4}>
+                      No items added.
+                    </Text>
+                    <Text>
+                      As you browse data and add entries to your Transfer List,
+                      they will appear here.
+                    </Text>
+                  </>
                 )}
                 {Object.keys(itemsByCollection).map((collection, i) => (
-                  <Card key={collection}>
+                  <Card key={collection} size="sm">
                     <CardHeader>
                       <Flex>
                         <Heading size="sm">
-                          Collection {i + 1} ({collection})
+                          <CollectionName id={collection} />
                         </Heading>
                         <Spacer />
                         {/* <Button size="xs">Remove Collection + Items</Button> */}
@@ -91,15 +121,6 @@ export default function TransferDrawer() {
                         {itemsByCollection[collection].map((item) => (
                           <Box key={item.subject}>
                             <HStack align="flex-start">
-                              <IconButton
-                                size="xs"
-                                variant="ghost"
-                                aria-label="Remove item from transfer list"
-                                icon={<Icon as={XCircleIcon} boxSize={4} />}
-                                onClick={() =>
-                                  removeItemBySubject(item.subject)
-                                }
-                              />
                               <Stack spacing={1}>
                                 <Link
                                   noOfLines={1}
@@ -110,12 +131,24 @@ export default function TransferDrawer() {
                                   {item.label}
                                 </Link>
                                 <Tooltip label={item.path}>
-                                  <Text noOfLines={1} fontSize="xs">
+                                  <Text
+                                    noOfLines={1}
+                                    fontSize="xs"
+                                    maxWidth="90%"
+                                  >
                                     {item.path}
                                   </Text>
                                 </Tooltip>
                               </Stack>
                               <Spacer />
+                              <IconButton
+                                variant="ghost"
+                                aria-label="Remove item from transfer list"
+                                icon={<Icon as={MinusCircleIcon} boxSize={6} />}
+                                onClick={() =>
+                                  removeItemBySubject(item.subject)
+                                }
+                              />
                             </HStack>
                           </Box>
                         ))}
@@ -125,13 +158,18 @@ export default function TransferDrawer() {
                 ))}
               </Stack>
               <Spacer />
-              <Button as={NextLink} href="/transfer" onClick={onClose}>
-                Configure Transfer
+              <Button
+                as={NextLink}
+                href="/transfer"
+                onClick={onClose}
+                isDisabled={items.length === 0}
+              >
+                Next Step: Configure your Transfer
               </Button>
             </Flex>
           </DrawerBody>
         </DrawerContent>
       </Drawer>
     </>
-  );
+  ) : null;
 }

--- a/src/components/Transfer/Drawer.tsx
+++ b/src/components/Transfer/Drawer.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  useDisclosure,
+  Button,
+  Box,
+  Link,
+  Heading,
+  Spacer,
+  Flex,
+  Text,
+  Stack,
+  Card,
+  CardHeader,
+  CardBody,
+  IconButton,
+  Icon,
+  HStack,
+  Tooltip,
+} from "@chakra-ui/react";
+
+import { Item, useGlobusTransferStore } from "@/store/globus-transfer";
+import NextLink from "next/link";
+import { XCircleIcon } from "@heroicons/react/24/outline";
+
+export default function TransferDrawer() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const items = useGlobusTransferStore((state) => state.items);
+  const removeItemBySubject = useGlobusTransferStore(
+    (state) => state.removeItemBySubject,
+  );
+
+  const itemsByCollection = items.reduce(
+    (acc: { [key: Item["collection"]]: Item[] }, item) => {
+      if (!acc[item.collection]) {
+        acc[item.collection] = [];
+      }
+      acc[item.collection].push(item);
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    <>
+      <Box pos="fixed" bottom={0} left={0} right={0}>
+        <Box p={2}>
+          <Button colorScheme="blue" onClick={onOpen}>
+            Transfer List ({items.length})
+          </Button>
+        </Box>
+      </Box>
+      <Drawer size="xl" placement="right" onClose={onClose} isOpen={isOpen}>
+        <DrawerOverlay />
+        <DrawerContent h="100vh">
+          <DrawerHeader borderBottomWidth="1px">
+            Transfer List <DrawerCloseButton />
+          </DrawerHeader>
+          <DrawerBody mt={2}>
+            <Flex h="100%" direction="column">
+              <Stack spacing={2}>
+                {items.length === 0 && (
+                  <Text as="em">No items added to transfer list.</Text>
+                )}
+                {Object.keys(itemsByCollection).map((collection, i) => (
+                  <Card key={collection}>
+                    <CardHeader>
+                      <Flex>
+                        <Heading size="sm">
+                          Collection {i + 1} ({collection})
+                        </Heading>
+                        <Spacer />
+                        {/* <Button size="xs">Remove Collection + Items</Button> */}
+                      </Flex>
+                    </CardHeader>
+                    <CardBody>
+                      <Stack overflow="hidden">
+                        {itemsByCollection[collection].map((item) => (
+                          <Box key={item.subject}>
+                            <HStack align="flex-start">
+                              <IconButton
+                                size="xs"
+                                variant="ghost"
+                                aria-label="Remove item from transfer list"
+                                icon={<Icon as={XCircleIcon} boxSize={4} />}
+                                onClick={() =>
+                                  removeItemBySubject(item.subject)
+                                }
+                              />
+                              <Stack spacing={1}>
+                                <Link
+                                  noOfLines={1}
+                                  as={NextLink}
+                                  href={`/results?subject=${item.subject}`}
+                                >
+                                  {item.label}
+                                </Link>
+                                <Tooltip label={item.path}>
+                                  <Text noOfLines={1} fontSize="xs">
+                                    {item.path}
+                                  </Text>
+                                </Tooltip>
+                              </Stack>
+                              <Spacer />
+                            </HStack>
+                          </Box>
+                        ))}
+                      </Stack>
+                    </CardBody>
+                  </Card>
+                ))}
+              </Stack>
+              <Spacer />
+              <Button as={NextLink} href="/transfer" onClick={onClose}>
+                Configure Transfer
+              </Button>
+            </Flex>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}

--- a/src/globus/Collection.tsx
+++ b/src/globus/Collection.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Code, Text, Tooltip } from "@chakra-ui/react";
+
+import { useCollection } from "@/hooks/useTransfer";
+
+export function CollectionName({ id }: { id: string }) {
+  const { data } = useCollection(id);
+  return (
+    <>
+      {data?.display_name ?? (
+        <Text>
+          Collection{" "}
+          <Tooltip label={id}>
+            <Code textDecoration="underline" textDecorationStyle="dashed">
+              {id.slice(0, 8)}
+            </Code>
+          </Tooltip>
+        </Text>
+      )}
+    </>
+  );
+}

--- a/src/globus/PathVerifier.tsx
+++ b/src/globus/PathVerifier.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from "react";
+import { transfer } from "@globus/sdk";
+import { useGlobusAuth } from "@globus/react-auth-context";
+import { Flex, Icon, Spinner, Text, Tooltip } from "@chakra-ui/react";
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from "@heroicons/react/24/outline";
+
+import { FileDocument } from "@globus/sdk/services/transfer/service/file-operations";
+import { QuestionIcon } from "@chakra-ui/icons";
+
+export default function PathVerifier({
+  path,
+  collectionId,
+}: {
+  path?: string;
+  collectionId?: string;
+}) {
+  const auth = useGlobusAuth();
+  const [isValidating, setIsValidating] = React.useState(false);
+  const [isValid, setIsValid] = React.useState<boolean | FileDocument>(null);
+
+  useEffect(() => {
+    async function validate() {
+      if (!collectionId || !path) {
+        return;
+      }
+      setIsValidating(true);
+      const res = await transfer.fileOperations.stat(
+        collectionId,
+        {
+          query: {
+            path,
+          },
+        },
+        { manager: auth.authorization },
+      );
+      setIsValid(res.ok);
+      setIsValidating(false);
+    }
+    validate();
+  }, [auth.authorization, path, collectionId]);
+
+  if (!path) {
+    return;
+  }
+
+  if (!collectionId) {
+    return;
+  }
+
+  return (
+    <Flex alignItems={"center"}>
+      {isValidating ? (
+        <Spinner mr={1} />
+      ) : isValid ? (
+        <Icon as={CheckCircleIcon} mr={1} />
+      ) : (
+        <Icon as={ExclamationCircleIcon} mr={1} />
+      )}
+      {!isValidating &&
+        (isValid ? (
+          <Text>Path exists on destination.</Text>
+        ) : (
+          <>
+            <Tooltip
+              hasArrow
+              label="We've attempted to reach the path you provided, but were unsuccessful. This might be intentional, or there might be a typo."
+              placement="bottom"
+            >
+              <Text
+                cursor={"help"}
+                textDecor={"underline"}
+                textDecorationStyle={"dashed"}
+              >
+                Unable to access path on destination.
+              </Text>
+            </Tooltip>
+          </>
+        ))}
+    </Flex>
+  );
+}

--- a/src/globus/PathVerifier.tsx
+++ b/src/globus/PathVerifier.tsx
@@ -24,7 +24,7 @@ import {
 } from "@globus/sdk/core/errors";
 
 import type { FileDocument } from "@globus/sdk/services/transfer/service/file-operations";
-import { setPostLoginRedirectUrl } from "@/app/authenticate/page";
+import { useOAuthStore } from "@/store/oauth";
 
 export default function PathVerifier({
   path,
@@ -34,6 +34,7 @@ export default function PathVerifier({
   collectionId?: string;
 }) {
   const auth = useGlobusAuth();
+  const oauthStore = useOAuthStore();
   const [isValidating, setIsValidating] = React.useState(false);
   const [isValid, setIsValid] = React.useState<null | boolean>(null);
   const [response, setResponse] = React.useState<FileDocument>();
@@ -91,7 +92,7 @@ export default function PathVerifier({
           size="xs"
           onClick={async () => {
             if (!response) return;
-            setPostLoginRedirectUrl("/transfer");
+            oauthStore.setReplaceWith("/transfer");
             await auth.authorization?.handleErrorResponse(response);
           }}
         >

--- a/src/globus/PathVerifier.tsx
+++ b/src/globus/PathVerifier.tsx
@@ -24,6 +24,7 @@ import {
 } from "@globus/sdk/core/errors";
 
 import type { FileDocument } from "@globus/sdk/services/transfer/service/file-operations";
+import { setPostLoginRedirectUrl } from "@/app/authenticate/page";
 
 export default function PathVerifier({
   path,
@@ -90,7 +91,8 @@ export default function PathVerifier({
           size="xs"
           onClick={async () => {
             if (!response) return;
-            await auth.authorization?.handleErrorResponse(response, false);
+            setPostLoginRedirectUrl("/transfer");
+            await auth.authorization?.handleErrorResponse(response);
           }}
         >
           Address

--- a/src/globus/collection-browser/CollectionBrowser.tsx
+++ b/src/globus/collection-browser/CollectionBrowser.tsx
@@ -16,9 +16,9 @@ import {
   Button,
 } from "@chakra-ui/react";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
-import { transfer } from "@globus/sdk/cjs";
+import { transfer } from "@globus/sdk";
 
-import { useGlobusAuth } from "../globus-auth-context/useGlobusAuth";
+import { useGlobusAuth } from "@globus/react-auth-context";
 
 type Endpoint = Record<string, any>;
 

--- a/src/globus/collection-browser/CollectionBrowser.tsx
+++ b/src/globus/collection-browser/CollectionBrowser.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  Icon,
+  List,
+  ListItem,
+  Card,
+  CardHeader,
+  Stack,
+  CardBody,
+  Text,
+  InputRightElement,
+  Button,
+} from "@chakra-ui/react";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { transfer } from "@globus/sdk/cjs";
+
+import { useGlobusAuth } from "../globus-auth-context/useGlobusAuth";
+
+type Endpoint = Record<string, any>;
+
+export function CollectionSearch({
+  onSelect = () => {},
+}: {
+  onSelect: (endpoint: Endpoint) => void;
+}) {
+  const auth = useGlobusAuth();
+  const [results, setResults] = useState<Endpoint[]>([]);
+  const [selection, setSelection] = useState<Endpoint | null>(null);
+
+  async function handleSearch(e: React.FormEvent<HTMLInputElement>) {
+    const query = e.currentTarget.value;
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    const response = await transfer.endpointSearch(
+      {
+        query: {
+          filter_fulltext: query,
+          limit: 20,
+        },
+      },
+      { manager: auth.authorization },
+    );
+    if (!response.ok) {
+      console.error("Error searching for endpoints:", response);
+      return;
+    }
+    const data = await response.json();
+    setResults(data.DATA);
+  }
+
+  function handleSelect(endpoint: Endpoint) {
+    setSelection(endpoint);
+    onSelect(endpoint);
+  }
+
+  if (selection) {
+    return (
+      <InputGroup>
+        <Input value={selection.display_name || selection.name} readOnly />
+        <InputRightElement width="4.5rem">
+          <Button h="1.75rem" size="sm" onClick={() => setSelection(null)}>
+            Clear
+          </Button>
+        </InputRightElement>
+      </InputGroup>
+    );
+  }
+
+  return (
+    <Stack>
+      <Box position="sticky" top="0" zIndex={1} bgColor="white">
+        <InputGroup>
+          <Input
+            onInput={(e) => handleSearch(e)}
+            placeholder="e.g. Globus Tutorial Collection"
+          />
+          <InputRightAddon>
+            <Icon as={MagnifyingGlassIcon} />
+          </InputRightAddon>
+        </InputGroup>
+      </Box>
+      <Stack maxH="400px" overflowY="auto">
+        {results.map((result) => (
+          <Card
+            size="sm"
+            variant="outline"
+            key={result.id}
+            onClick={() => handleSelect(result)}
+            _hover={{ cursor: "pointer", borderColor: "blue.500" }}
+          >
+            <CardHeader pb={0}>
+              <Text>{result.display_name || result.name}</Text>
+              <Text fontSize="xs">{result.entity_type}</Text>
+            </CardHeader>
+            <CardBody>
+              <List>
+                <Text fontSize="xs">
+                  <ListItem>ID: {result.id}</ListItem>
+                  <ListItem>Owner: {result.owner_id}</ListItem>
+                  <ListItem>Domain: {result.domain || "\u2014"}</ListItem>
+                  <ListItem>
+                    <Text noOfLines={1}>
+                      Description: {result.description || "\u2014"}
+                    </Text>
+                  </ListItem>
+                </Text>
+              </List>
+            </CardBody>
+          </Card>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/globus/collection-browser/CollectionBrowser.tsx
+++ b/src/globus/collection-browser/CollectionBrowser.tsx
@@ -100,17 +100,15 @@ export function CollectionSearch({
               <Text fontSize="xs">{result.entity_type}</Text>
             </CardHeader>
             <CardBody>
-              <List>
-                <Text fontSize="xs">
-                  <ListItem>ID: {result.id}</ListItem>
-                  <ListItem>Owner: {result.owner_id}</ListItem>
-                  <ListItem>Domain: {result.domain || "\u2014"}</ListItem>
-                  <ListItem>
-                    <Text noOfLines={1}>
-                      Description: {result.description || "\u2014"}
-                    </Text>
-                  </ListItem>
-                </Text>
+              <List fontSize="xs">
+                <ListItem>ID: {result.id}</ListItem>
+                <ListItem>Owner: {result.owner_id}</ListItem>
+                <ListItem>Domain: {result.domain || "\u2014"}</ListItem>
+                <ListItem>
+                  <Text noOfLines={1}>
+                    Description: {result.description || "\u2014"}
+                  </Text>
+                </ListItem>
               </List>
             </CardBody>
           </Card>

--- a/src/globus/collection-browser/CollectionBrowser.tsx
+++ b/src/globus/collection-browser/CollectionBrowser.tsx
@@ -20,16 +20,18 @@ import { transfer } from "@globus/sdk";
 
 import { useGlobusAuth } from "@globus/react-auth-context";
 
-type Endpoint = Record<string, any>;
+export type Endpoint = Record<string, any>;
 
 export function CollectionSearch({
+  defaultValue = null,
   onSelect = () => {},
 }: {
+  defaultValue?: Endpoint | null;
   onSelect: (endpoint: Endpoint) => void;
 }) {
   const auth = useGlobusAuth();
   const [results, setResults] = useState<Endpoint[]>([]);
-  const [selection, setSelection] = useState<Endpoint | null>(null);
+  const [selection, setSelection] = useState(defaultValue);
 
   async function handleSearch(e: React.FormEvent<HTMLInputElement>) {
     const query = e.currentTarget.value;

--- a/src/globus/utils.ts
+++ b/src/globus/utils.ts
@@ -1,0 +1,6 @@
+export const CLIENT_INFO = {
+  product: "@globus/static-search-portal",
+  // x-release-please-start-version
+  version: "0.8.3",
+  // x-release-please-end
+};

--- a/src/hooks/useTransfer.ts
+++ b/src/hooks/useTransfer.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { transfer } from "@globus/sdk";
+import { useGlobusAuth } from "@globus/react-auth-context";
+
+import { type AuthorizationManager } from "@globus/sdk/core/authorization/AuthorizationManager";
+
+export async function fetchCollection(
+  authorization: AuthorizationManager | undefined,
+  id: string,
+) {
+  const response = await transfer.endpoint.get(
+    id,
+    {},
+    { manager: authorization },
+  );
+  return response.json();
+}
+
+export function useCollection(id: string) {
+  const auth = useGlobusAuth();
+  return useQuery({
+    enabled: auth.isAuthenticated,
+    queryKey: ["collections", id],
+    queryFn: () => fetchCollection(auth.authorization, id),
+  });
+}

--- a/src/store/globus-transfer.ts
+++ b/src/store/globus-transfer.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export type Item = {
+  label: string;
+  collection: string;
+  path: string;
+  subject: string;
+  type: "file" | "directory";
+};
+
+type State = {
+  items: Item[];
+};
+
+type Actions = {
+  removeItemBySubject: (subject: Item["subject"]) => void;
+  addItem: (item: Item) => void;
+  reset: () => void;
+};
+
+const initialState = {
+  items: [],
+};
+
+export const useGlobusTransferStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      addItem: (item) => {
+        return set((state) => ({
+          items: [...state.items, item],
+        }));
+      },
+      removeItemBySubject: (item) => {
+        return set((state) => ({
+          items: state.items.filter((i) => i.subject !== item),
+        }));
+      },
+      reset: () => {
+        return set(initialState);
+      },
+    }),
+    {
+      name: "globus-transfer",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/src/store/globus-transfer.ts
+++ b/src/store/globus-transfer.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
+import type { Endpoint } from "@/globus/collection-browser/CollectionBrowser";
+
+/**
+ * Items that will be transferred to the destination.
+ */
 export type Item = {
   label: string;
   collection: string;
@@ -8,12 +13,24 @@ export type Item = {
   subject: string;
   type: "file" | "directory";
 };
+/**
+ * Represents the information required to initiate a Globus transfer of the items.
+ */
+export type Transfer = {
+  destination?: Endpoint;
+  path?: string;
+  label?: string;
+};
 
 type State = {
   items: Item[];
+  transfer?: Transfer;
 };
 
 type Actions = {
+  setLabel: (label: string) => void;
+  setDestination: (destination: Endpoint) => void;
+  setPath: (path: string) => void;
   removeItemBySubject: (subject: Item["subject"]) => void;
   addItem: (item: Item) => void;
   reset: () => void;
@@ -21,19 +38,49 @@ type Actions = {
 
 const initialState = {
   items: [],
+  transfer: undefined,
 };
 
 export const useGlobusTransferStore = create<State & Actions>()(
   persist(
     (set) => ({
       ...initialState,
+      setLabel: (label: string) => {
+        return set((state) => ({
+          ...state,
+          transfer: {
+            ...state.transfer,
+            label,
+          },
+        }));
+      },
+      setDestination: (destination: Endpoint) => {
+        return set((state) => ({
+          ...state,
+          transfer: {
+            ...state.transfer,
+            destination,
+          },
+        }));
+      },
+      setPath: (path: string) => {
+        return set((state) => ({
+          ...state,
+          transfer: {
+            ...state.transfer,
+            path,
+          },
+        }));
+      },
       addItem: (item) => {
         return set((state) => ({
+          ...state,
           items: [...state.items, item],
         }));
       },
       removeItemBySubject: (item) => {
         return set((state) => ({
+          ...state,
           items: state.items.filter((i) => i.subject !== item),
         }));
       },

--- a/src/store/oauth.ts
+++ b/src/store/oauth.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+type State = {
+  replaceWith: string;
+};
+
+type Action = {
+  setReplaceWith: (path: string) => void;
+  reset: () => void;
+};
+
+const initialState = {
+  replaceWith: "/",
+};
+
+export const useOAuthStore = create<State & Action>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      setReplaceWith: (replaceWith: string) => {
+        return set((state) => ({
+          ...state,
+          replaceWith,
+        }));
+      },
+      reset: () => {
+        return set(initialState);
+      },
+    }),
+    {
+      name: "oauth",
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);

--- a/static.ts
+++ b/static.ts
@@ -1,8 +1,9 @@
 import _STATIC from "./static.json";
 import { defaultsDeep, get as _get } from "lodash";
-import type { ResultComponentOptions } from "@/components/Result";
-import { ResultListingComponentOptions } from "@/components/ResultListing";
 import { ThemeSettings } from "@/theme";
+
+import type { ResultListingComponentOptions } from "@/components/ResultListing";
+import type { ResultComponentOptions } from "@/components/Result";
 
 /**
  * The base type for a `static.json` file.
@@ -52,6 +53,7 @@ export type Data = {
        */
       jsonata?: boolean;
       authentication?: boolean;
+      transfer?: boolean;
     };
 
     theme?: ThemeSettings;
@@ -259,3 +261,13 @@ export async function getValueFrom<T>(
   }
   return _get(obj, key, defaultValue);
 }
+
+/**
+ * Whether or not the Globus Transfer is enabled based on the state of the `static.json`.
+ */
+export const isTransferEnabled = Boolean(
+  getAttribute(
+    "features.transfer",
+    getAttribute("components.Result.globus.transfer"),
+  ),
+);

--- a/static.ts
+++ b/static.ts
@@ -1,4 +1,4 @@
-import _STATIC from "./static.json";
+import _STATIC from "./static-lsst-desc.json";
 import { defaultsDeep, get as _get } from "lodash";
 import { ThemeSettings } from "@/theme";
 
@@ -271,3 +271,10 @@ export const isTransferEnabled = Boolean(
     getAttribute("components.Result.globus.transfer"),
   ),
 );
+
+/**
+ * Whether or not a user can "Sign In" to the portal.
+ * If Transfer functionality is enabled (`isTransferEnabled`), then authentication is enabled.
+ */
+export const isAuthenticationEnabled =
+  isTransferEnabled || isFeatureEnabled("authentication");

--- a/static.ts
+++ b/static.ts
@@ -1,4 +1,4 @@
-import _STATIC from "./static-lsst-desc.json";
+import _STATIC from "./static.json";
 import { defaultsDeep, get as _get } from "lodash";
 import { ThemeSettings } from "@/theme";
 


### PR DESCRIPTION
### Globus Transfer Support

Globus Transfer support can be enabled in search portals in one of two ways:

1. Enabling the feature-flag and adding well-known properties to search documents.
   - Set `features.transfer` to `true` in your `static.json` file.
   - Update your Globus Search Index documents to include a `globus` property:
      - `{ "globus: { "transfer": { "collection": "<UUID>", "path": "<PATH>"} } }`
      - Optional: Provide a `type` of `file` or `directory` describing the `path` to control whether or not a `recursive` Transfer is made.
2. Configuring `components.Result.globus.transfer`
   - `{ "collection": string, "path": string, type?: "file" | "directory"}`
   - A JSONata property can also be used to support dynamically sourcing a value from the result document.
      - `{ "collection": { "property": "$split($split($split(entries[0].content.remote_file_manifest[0].url, 'globus://')[1], '/')[0], '.')[0]" } }`


When the Transfer functionality is enabled...
- The Globus Transfer scope will be requested for users upon login.
- An "Add to Transfer List" button will be visible on results.
- A "Transfer List" button will be added to the header.
- Once a user selects files for transfer, they can configure the destination collection, path, and label.

<div>
    <a href="https://www.loom.com/share/9082645692e84e099d456898be452430">
      <p>Search Portal : Feature Preview : Transfer Integration - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/9082645692e84e099d456898be452430">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/9082645692e84e099d456898be452430-2db73a4ae55eaaf7-full-play.gif">
    </a>
  </div>


chore: Allows enabling and disabling of Globus Transfer features via `features.transfer` property in `static.json` file.
chore: adds search-portal-specific client information
chore: use zustand for state storage

