### PR TITLE
feat: use 'primary' and 'secondary' colors for styling

### DIFF
--- a/src/components/Fields/ImageField.tsx
+++ b/src/components/Fields/ImageField.tsx
@@ -61,7 +61,7 @@ export default function ImageField({ value }: { value: unknown }) {
               <Box height="5rem" width="5rem" pos="relative">
                 {loading && (
                   <AbsoluteCenter>
-                    <Spinner emptyColor="gray.200" color="brand.500" />
+                    <Spinner emptyColor="gray.200" color="primary.500" />
                   </AbsoluteCenter>
                 )}
                 {error && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -79,7 +79,7 @@ export default function Header() {
   return (
     <Flex
       as="header"
-      bg="brand.800"
+      bg="primary.800"
       minH={{ base: "50px", md: "10vh" }}
       align="center"
       justify="center"

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -250,7 +250,7 @@ function Result({ result }: { result: GMetaResult }) {
   return (
     <>
       <Flex>
-        <Heading as="h1" size="md" color="brand">
+        <Heading as="h1" size="md" color="primary">
           {heading || (
             <Text as="em" color="gray.500">
               &mdash;

--- a/src/components/ResultListing.tsx
+++ b/src/components/ResultListing.tsx
@@ -162,7 +162,7 @@ export default function ResultListing({ gmeta }: { gmeta: GMetaResult }) {
   return (
     <Card size="sm" w="full">
       <CardHeader>
-        <Heading size="md" color="brand">
+        <Heading size="md" color="primary">
           <HStack>
             <Link
               as={NextLink}

--- a/src/components/Transfer/Drawer.tsx
+++ b/src/components/Transfer/Drawer.tsx
@@ -64,11 +64,11 @@ export default function TransferDrawer() {
         <Button
           isDisabled={pathname === "/transfer"}
           size="sm"
-          colorScheme="brand"
+          colorScheme="primary"
           onClick={onOpen}
         >
           Transfer List
-          <Badge ml={2} colorScheme="brand">
+          <Badge ml={2} colorScheme="primary">
             {items.length}
           </Badge>
         </Button>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,10 @@
 import { STATIC } from "../static";
 
-import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
+import {
+  theme as baseTheme,
+  extendTheme,
+  withDefaultColorScheme,
+} from "@chakra-ui/react";
 
 import "@fontsource/ibm-plex-mono";
 import "@fontsource/ibm-plex-sans";
@@ -29,12 +33,12 @@ export type ThemeSettings = {
   colorScheme?: string;
   /**
    * Specific color definitions to use in the theme.
-   * The most common use case is to define a `brand` color.
+   * The most common use case is to define a `primary` color.
    * @example
    * ```json
    * {
    *   "colors": {
-   *     "brand": {
+   *     "primary": {
    *      "50": "#E5F2FF",
    *      "100": "#B8DBFF",
    *      "200": "#8AC4FF",
@@ -59,7 +63,7 @@ export type ThemeSettings = {
   extendTheme?: Parameters<typeof extendTheme>[0];
 };
 
-const brand: ColorDefinition = {
+const primary: ColorDefinition = {
   "50": "#E5F2FF",
   "100": "#B8DBFF",
   "200": "#8AC4FF",
@@ -71,6 +75,8 @@ const brand: ColorDefinition = {
   "800": "#00264c",
   "900": "#001933",
 };
+
+const secondary = baseTheme.colors.gray;
 
 let colorScheme = {};
 if (STATIC.data.attributes.theme?.colorScheme) {
@@ -87,7 +93,11 @@ const theme = extendTheme(
       mono: `'IBM Plex Mono', monospace`,
     },
     colors: {
-      brand,
+      /**
+       * Allow the legacy "brand" to be used as the primary color.
+       */
+      primary: STATIC.data.attributes.theme?.colors?.brand || primary,
+      secondary,
       ...(STATIC.data.attributes.theme?.colors || {}),
     },
   },


### PR DESCRIPTION
- `brand` theme definition values will be used as the `primary` to stay backwards compatible with existing `static.json` files.