### PR TITLE
feat: Adds support for rendering fields a links.

### DIFF
--- a/__tests__/components/Result.test.tsx
+++ b/__tests__/components/Result.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { render } from "../../test-utils";
 
 import result from "../fixtures/GMetaResult.json";
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom";
+
+import { setConfig } from "next/config";
+import config from "./next.config.mjs";
+setConfig({
+  publicRuntimeConfig: config.publicRuntimeConfig,
+});

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -70,7 +70,15 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
        * If the link is external, mark it as such.
        */
       return (
-        <Link {...rest} href={href} position="relative" pr={4} isExternal>
+        <Link
+          {...rest}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={href}
+          position="relative"
+          pr={4}
+          isExternal
+        >
           {rest.children}
           <ExternalLinkIcon
             as="sup"

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -6,6 +6,7 @@ import jsonata from "jsonata";
 import RgbaField from "./Fields/RgbaField";
 import ImageField from "./Fields/ImageField";
 import TableField from "./Fields/TableField";
+import LinkField from "./Fields/LinkField";
 import FallbackField from "./Fields/FallbackField";
 
 import { GMetaResult } from "@globus/sdk/services/search/service/query";
@@ -73,6 +74,10 @@ export const FieldValue = ({
   if (type === "table") {
     return <TableField value={value} />;
   }
+  if (type === "link") {
+    return <LinkField value={value} />;
+  }
+
   /**
    * If no `type` is provided, or the `type` is not recognized, use the fallback field.
    */

--- a/src/components/Fields/LinkField.tsx
+++ b/src/components/Fields/LinkField.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import NextLink from "next/link";
+import { Link } from "@chakra-ui/react";
+import { isRelativePath } from "@/utils/path";
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+
+type Value = string;
+
+function isValidValue(value: unknown): value is Value {
+  return typeof value === "string";
+}
+
+/**
+ * Render a field as a link.
+ */
+export default function LinkField({ value }: { value: unknown }) {
+  if (!isValidValue(value)) {
+    return;
+  }
+  const isRelative = isRelativePath(value);
+  if (isRelative) {
+    /**
+     * If the link is relative, use Next.js's `Link` component.
+     */
+    return (
+      <Link as={NextLink} href={value}>
+        {value}
+      </Link>
+    );
+  }
+  return (
+    <Link
+      target="_blank"
+      rel="noopener noreferrer"
+      href={value}
+      position="relative"
+      pr={4}
+      isExternal
+    >
+      {value}
+      <ExternalLinkIcon
+        as="sup"
+        position="absolute"
+        top={0}
+        right={0}
+        fontSize="xs"
+      />
+    </Link>
+  );
+}

--- a/test-utils.tsx
+++ b/test-utils.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from "react";
+import { render as _render, RenderOptions } from "@testing-library/react";
+import { Provider as GlobusAuthorizationManagerProvider } from "@globus/react-auth-context";
+
+const Providers = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <GlobusAuthorizationManagerProvider client="abc" redirect="#">
+      {children}
+    </GlobusAuthorizationManagerProvider>
+  );
+};
+
+// eslint-disable-next-line import/export
+export * from "@testing-library/react";
+// eslint-disable-next-line import/export
+export const render = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">,
+) => {
+  _render(ui, { wrapper: Providers, ...options });
+};


### PR DESCRIPTION
Using `"type": "link"` will render a field value as a link in Result and ResultListing components.

```json
{
  "label": "Documentation",
  "property": "entries[0].content.documentation",
  "type": "link"
},
{
  "label": "More Details",
  "value": "https://www.globus.org",
  "type": "link"
}
```
<img width="252" alt="Screenshot 2024-10-11 at 7 46 15 AM" src="https://github.com/user-attachments/assets/05eae281-c6ca-41e4-af63-e433a3cf2e6d">

Supports absolute and relative links.
