### PR TITLE
feat: adds support for rendering embedded Globus assets as a Plotly graph or chart

### DIFF
--- a/__tests__/components/Fields/GlobusEmbedField.tsx
+++ b/__tests__/components/Fields/GlobusEmbedField.tsx
@@ -9,7 +9,6 @@ describe("GlobusEmbedField", () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       blob: jest.fn().mockResolvedValue(new Blob()),
-      json: jest.fn().mockResolvedValue({}),
       headers: {
         get: jest.fn().mockReturnValue("image/jpeg"),
       },
@@ -39,6 +38,9 @@ describe("GlobusEmbedField", () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       blob: jest.fn().mockResolvedValue(new Blob()),
+      headers: {
+        get: jest.fn().mockReturnValue("image/jpeg"),
+      },
     });
     global.URL.createObjectURL = jest
       .fn()

--- a/__tests__/components/Fields/GlobusEmbedField.tsx
+++ b/__tests__/components/Fields/GlobusEmbedField.tsx
@@ -9,6 +9,10 @@ describe("GlobusEmbedField", () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       blob: jest.fn().mockResolvedValue(new Blob()),
+      json: jest.fn().mockResolvedValue({}),
+      headers: {
+        get: jest.fn().mockReturnValue("image/jpeg"),
+      },
     });
     global.URL.createObjectURL = jest
       .fn()

--- a/docs/-internal-/type-aliases/ColorDefinition.md
+++ b/docs/-internal-/type-aliases/ColorDefinition.md
@@ -8,4 +8,4 @@
 
 ## Source
 
-[src/theme.ts:12](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/theme.ts#L12)
+[src/theme.ts:12](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/theme.ts#L12)

--- a/docs/-internal-/type-aliases/FieldDefinition.md
+++ b/docs/-internal-/type-aliases/FieldDefinition.md
@@ -8,4 +8,4 @@
 
 ## Source
 
-[src/components/Field.tsx:28](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Field.tsx#L28)
+[src/components/Field.tsx:28](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Field.tsx#L28)

--- a/docs/-internal-/type-aliases/GlobusTransferOptions.md
+++ b/docs/-internal-/type-aliases/GlobusTransferOptions.md
@@ -26,4 +26,4 @@ The path that will be used as the `source_path` for the transfer.
 
 ## Source
 
-[src/components/Result.tsx:49](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Result.tsx#L49)
+[src/components/Result.tsx:49](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Result.tsx#L49)

--- a/docs/-internal-/type-aliases/LinkDefinition.md
+++ b/docs/-internal-/type-aliases/LinkDefinition.md
@@ -22,4 +22,4 @@ The label that will be rendered as the link text.
 
 ## Source
 
-[src/components/Result.tsx:30](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Result.tsx#L30)
+[src/components/Result.tsx:30](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Result.tsx#L30)

--- a/docs/-internal-/type-aliases/NavigationItem.md
+++ b/docs/-internal-/type-aliases/NavigationItem.md
@@ -8,4 +8,4 @@
 
 ## Source
 
-[src/components/Navigation.tsx:22](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Navigation.tsx#L22)
+[src/components/Navigation.tsx:22](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Navigation.tsx#L22)

--- a/docs/-internal-/type-aliases/NavigationOptions.md
+++ b/docs/-internal-/type-aliases/NavigationOptions.md
@@ -14,4 +14,4 @@
 
 ## Source
 
-[src/components/Navigation.tsx:34](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Navigation.tsx#L34)
+[src/components/Navigation.tsx:34](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Navigation.tsx#L34)

--- a/docs/-internal-/type-aliases/ResultComponentOptions.md
+++ b/docs/-internal-/type-aliases/ResultComponentOptions.md
@@ -83,4 +83,4 @@ https://docs.globus.org/api/search/reference/get_subject/#gmetaresult
 
 ## Source
 
-[src/components/Result.tsx:82](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Result.tsx#L82)
+[src/components/Result.tsx:82](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Result.tsx#L82)

--- a/docs/-internal-/type-aliases/ResultListingComponentOptions.md
+++ b/docs/-internal-/type-aliases/ResultListingComponentOptions.md
@@ -81,4 +81,4 @@ https://docs.globus.org/api/search/reference/get_subject/#gmetaresult
 
 ## Source
 
-[src/components/ResultListing.tsx:31](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/ResultListing.tsx#L31)
+[src/components/ResultListing.tsx:31](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/ResultListing.tsx#L31)

--- a/docs/-internal-/type-aliases/SharedDefinitionProperties.md
+++ b/docs/-internal-/type-aliases/SharedDefinitionProperties.md
@@ -26,4 +26,4 @@ An option `type` to specify how the field should be rendered.
 
 ## Source
 
-[src/components/Field.tsx:16](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/components/Field.tsx#L16)
+[src/components/Field.tsx:16](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/components/Field.tsx#L16)

--- a/docs/-internal-/type-aliases/ThemeSettings.md
+++ b/docs/-internal-/type-aliases/ThemeSettings.md
@@ -63,4 +63,4 @@ https://v2.chakra-ui.com/docs/styled-system/customize-theme#using-theme-extensio
 
 ## Source
 
-[src/theme.ts:27](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/src/theme.ts#L27)
+[src/theme.ts:27](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/src/theme.ts#L27)

--- a/docs/functions/getEnvironment.md
+++ b/docs/functions/getEnvironment.md
@@ -12,4 +12,4 @@
 
 ## Source
 
-[static.ts:202](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L202)
+[static.ts:202](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L202)

--- a/docs/functions/getValueFrom.md
+++ b/docs/functions/getValueFrom.md
@@ -24,4 +24,4 @@
 
 ## Source
 
-[static.ts:283](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L283)
+[static.ts:283](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L283)

--- a/docs/type-aliases/Base.md
+++ b/docs/type-aliases/Base.md
@@ -71,4 +71,4 @@ https://github.com/from-static/actions
 
 ## Source
 
-[static.ts:12](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L12)
+[static.ts:12](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L12)

--- a/docs/type-aliases/Data.md
+++ b/docs/type-aliases/Data.md
@@ -188,4 +188,4 @@ the generator will render its `attributes`.
 
 ## Source
 
-[static.ts:42](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L42)
+[static.ts:42](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L42)

--- a/docs/type-aliases/Static.md
+++ b/docs/type-aliases/Static.md
@@ -14,4 +14,4 @@
 
 ## Source
 
-[static.ts:155](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L155)
+[static.ts:155](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L155)

--- a/docs/variables/METADATA.md
+++ b/docs/variables/METADATA.md
@@ -18,4 +18,4 @@
 
 ## Source
 
-[static.ts:318](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L318)
+[static.ts:318](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L318)

--- a/docs/variables/areSEOResultsEnabled.md
+++ b/docs/variables/areSEOResultsEnabled.md
@@ -8,4 +8,4 @@
 
 ## Source
 
-[static.ts:316](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L316)
+[static.ts:316](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L316)

--- a/docs/variables/isAuthenticationEnabled.md
+++ b/docs/variables/isAuthenticationEnabled.md
@@ -11,4 +11,4 @@ If Transfer functionality is enabled (`isTransferEnabled`), then authentication 
 
 ## Source
 
-[static.ts:313](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L313)
+[static.ts:313](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L313)

--- a/docs/variables/isTransferEnabled.md
+++ b/docs/variables/isTransferEnabled.md
@@ -10,4 +10,4 @@ Whether or not the Globus Transfer is enabled based on the state of the `static.
 
 ## Source
 
-[static.ts:302](https://github.com/globus/static-search-portal/blob/baa2d7ee8b5271b1d58d6455e5096e077c19aecd/static.ts#L302)
+[static.ts:302](https://github.com/globus/static-search-portal/blob/070e36d2f911e99d43e515c735c6dc05f429a795/static.ts#L302)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "framer-motion": "^11.11.11",
         "lodash": "^4.17.21",
         "next": "14.2.15",
+        "plotly.js-dist-min": "^2.35.2",
         "react": "^18",
         "react-dom": "^18",
         "zustand": "^5.0.1"
@@ -37,6 +38,7 @@
         "@testing-library/react": "^16.0.1",
         "@types/jest": "^29.5.13",
         "@types/node": "^20",
+        "@types/plotly.js-dist-min": "^2.3.4",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8.57.1",
@@ -2454,6 +2456,23 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+    },
+    "node_modules/@types/plotly.js": {
+      "version": "2.33.5",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.33.5.tgz",
+      "integrity": "sha512-TSXtrlc/4Zz7FP8HyDjmhsFFZ9JlzRk0KdHxXieDno4yZB4Jm5ET873QH+qPm5iZMaRZAEJMOrs1AGgN7r4e4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/plotly.js-dist-min": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js-dist-min/-/plotly.js-dist-min-2.3.4.tgz",
+      "integrity": "sha512-ISwLFV6Zs/v3DkaRFLyk2rvYAfVdnYP2VVVy7h+fBDWw52sn7sMUzytkWiN4M75uxr1uz1uiBioePTDpAfoFIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/plotly.js": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
@@ -9569,6 +9588,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/plotly.js-dist-min": {
+      "version": "2.35.2",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.35.2.tgz",
+      "integrity": "sha512-oWDTf2kYOmTtEw3epeeSBdfH/H3OSktF0suST9oI6fIgKfbyd4MT7TPh8+CVzdHYllYon24Q0HI1hZjOnLqk6g==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "framer-motion": "^11.11.11",
     "lodash": "^4.17.21",
     "next": "14.2.15",
+    "plotly.js-dist-min": "^2.35.2",
     "react": "^18",
     "react-dom": "^18",
     "zustand": "^5.0.1"
@@ -43,6 +44,7 @@
     "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.13",
     "@types/node": "^20",
+    "@types/plotly.js-dist-min": "^2.3.4",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8.57.1",

--- a/src/components/Fields/GlobusEmbedField.tsx
+++ b/src/components/Fields/GlobusEmbedField.tsx
@@ -30,12 +30,15 @@ type SharedOptions = {
   /**
    * When using the default renderer, the MIME type of the `<object>` can be
    * specified using this option. If not provided, the MIME type will be
-   * inferred from the file extension.
+   * inferred from the "Content-Type" header in the asset response.
    */
   mime?: string;
   /**
    * The renderer that will be used to display the asset. By default,
    * the asset will be rendered as an `<object>` in a sandboxed `<iframe>`.
+   *
+   * - `plotly` will render the asset as a Plotly chart. When using this renderer, the asset should be a JSON file than can
+   * be passed as the configuration object for your chart; See https://plotly.com/javascript/plotlyjs-function-reference/#plotlynewplot) for more details.
    */
   renderer?: Renderers;
 

--- a/src/components/Fields/Renderer/Plotly.tsx
+++ b/src/components/Fields/Renderer/Plotly.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from "react";
+import { Box } from "@chakra-ui/react";
+
+/**
+ * A Plotly renderer that can be used to render Plotly charts in a portal.
+ * @see https://plotly.com/javascript/
+ */
+export function Plotly(
+  props: {
+    /**
+     * The contents of the field that will be rendered as a Plotly chart.
+     */
+    contents: Record<string, unknown>;
+  } & React.ComponentProps<typeof Box>,
+) {
+  const { contents, ...rest } = props;
+
+  const landing = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    async function renderPlotly() {
+      if (!landing.current) return;
+      /**
+       * We dynamically import Plotly in the renderer to ensure the library is only loaded
+       * when a portal has opted to use the Plotly renderer.
+       */
+      const Plotly = (await import("plotly.js-dist-min")).default;
+      Plotly.newPlot(
+        landing.current,
+        contents as unknown as Parameters<
+          typeof import("plotly.js-dist-min").newPlot
+        >[1],
+      );
+    }
+    renderPlotly();
+  });
+
+  return <Box ref={landing} {...rest} />;
+}


### PR DESCRIPTION
fix: use the returned "Content-Type" header of `globus.embed` fields as the default mime.