### PR TITLE
feat: Adds JSON Renderer for Globus Embeds

### DIFF
--- a/src/components/Fields/GlobusEmbedField.tsx
+++ b/src/components/Fields/GlobusEmbedField.tsx
@@ -27,10 +27,11 @@ import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { useLogin } from "@/hooks/useOAuth";
 import { PlotlyRenderer } from "./Renderer/Plotly";
 import { ObjectRenderer } from "./Renderer/Object";
+import { JsonRenderer } from "./Renderer/Json";
 import { useGCSAsset, useGCSAssetMetadata } from "@/hooks/useGlobusAPI";
 import { JSONTree } from "../JSONTree";
 
-type Renderers = "plotly" | "editor" | undefined;
+export type Renderers = "plotly" | "json" | undefined;
 
 type SharedOptions = {
   /**
@@ -203,7 +204,13 @@ function GlobusEmbed({ config, field }: GlobusEmbedProps) {
   const { width = "100%", height = "auto" } = config;
 
   const renderer = config.renderer || asset.data?.renderer;
-  const Renderer = renderer === "plotly" ? PlotlyRenderer : ObjectRenderer;
+
+  const Renderer =
+    renderer === "plotly"
+      ? PlotlyRenderer
+      : renderer === "json"
+        ? JsonRenderer
+        : ObjectRenderer;
 
   return (
     <>

--- a/src/components/Fields/Renderer/Json.tsx
+++ b/src/components/Fields/Renderer/Json.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+import { GlobusEmbedProps } from "../GlobusEmbedField";
+import { useGCSAsset } from "@/hooks/useGlobusAPI";
+import { JSONTree } from "@/components/JSONTree";
+
+/**
+ * Render JSON data.
+ */
+export function JsonRenderer(props: GlobusEmbedProps) {
+  const { config } = props;
+  // const { width = "100%", height = "auto" } = config;
+
+  const [value, setValue] = useState<unknown>();
+
+  const asset = useGCSAsset({
+    collection: config.collection,
+    url: config.asset,
+  });
+
+  useEffect(() => {
+    async function renderAsset() {
+      if (asset.data) {
+        setValue(await asset.data?.content);
+      }
+    }
+    renderAsset();
+  }, [asset.data]);
+
+  return <JSONTree data={value} />;
+}

--- a/src/hooks/useGlobusAPI.ts
+++ b/src/hooks/useGlobusAPI.ts
@@ -5,6 +5,7 @@ import { useGlobusAuth } from "@globus/react-auth-context";
 import { type AuthorizationManager } from "@globus/sdk/core/authorization/AuthorizationManager";
 
 import { STATIC } from "../../static";
+import type { Renderers } from "@/components/Fields/GlobusEmbedField";
 
 async function fetchCollection(
   authorization: AuthorizationManager | undefined,
@@ -127,7 +128,7 @@ type GCSAssetResponse = {
    * `renderer` that should be used to render the asset based on the observed Content-Type and user-provided `mime` type.
    * During actual rendering a user-provided `renderer` should take precedence over the inferred `renderer`.
    */
-  renderer?: "plotly";
+  renderer?: Renderers;
   content: Promise<any>;
   /**
    * The `mime` type of the asset set by the user or inferred `mime` type based on the asset response.
@@ -231,6 +232,7 @@ export function useGCSAsset({
           content: response.json(),
           mime: contentType,
           contentType,
+          renderer: "json",
         };
       }
       return {


### PR DESCRIPTION
Globus-embedded JSON files will now use a JSON tree view renderer. The JSON Renderer will be used automatically when the embedded file returns an `application/json` Content-Type.